### PR TITLE
Bitwise xor binary operator added using ^

### DIFF
--- a/src/examples/bitwise.prse
+++ b/src/examples/bitwise.prse
@@ -4,6 +4,8 @@ func main(){
     let a : int = 15;
     let b : int = 16;
     let c : int = a ^ b;
+    let d : int = 15 ^ 16;
     println("hello world");
     println(c);
+    println(d);
 }

--- a/src/examples/bitwise.prse
+++ b/src/examples/bitwise.prse
@@ -1,0 +1,9 @@
+use "io"
+
+func main(){
+    let a : int = 15;
+    let b : int = 16;
+    let c : int = a ^ b;
+    println("hello world");
+    println(c);
+}

--- a/src/lib/expressions/Bitwise.cpp
+++ b/src/lib/expressions/Bitwise.cpp
@@ -1,0 +1,55 @@
+#include "Bitwise.h"
+#include "Expression_core.h"
+#include "Valid_math_types.h"
+
+const Constant* Xor::as_const() const {
+    if (lhs != nullptr && rhs != nullptr){
+        auto l = lhs->as_const();
+        auto r = rhs->as_const();
+        if(!(l->type() & VALID_MATH_TYPES)){
+            Error::error(Error::INVALID_EXPRESSION_TYPE_FOR_OPERATION, "lhs", prse_type_to_string(l->type()), "Bitwise Xor", line);
+        }
+        if (!(r->type() & VALID_MATH_TYPES)){
+            Error::error(Error::INVALID_EXPRESSION_TYPE_FOR_OPERATION, "rhs", prse_type_to_string(l->type()), "Bitwise Xor", line);
+        }
+        string emit  = l->value() + " ^ " + r->value();
+        return ret(new Constant(l->type(), emit));
+    }
+        else{
+            return ret(new Constant(PRSE_type::NO_TYPE,""));
+        }
+}
+
+string Xor::value() const {
+    if (lhs != nullptr && rhs != nullptr){
+        auto l = lhs->as_const();
+        auto r = rhs->as_const();
+        if(!(l->type() & VALID_MATH_TYPES)){
+            Error::error(Error::INVALID_EXPRESSION_TYPE_FOR_OPERATION, "lhs", prse_type_to_string(l->type()), "Bitwise Xor", line);
+        }
+        if (!(r->type() & VALID_MATH_TYPES)){
+            Error::error(Error::INVALID_EXPRESSION_TYPE_FOR_OPERATION, "rhs", prse_type_to_string(l->type()), "Bitwise Xor", line);
+        }
+        string emit  = l->value() + " ^ " + r->value();
+        return emit;
+    }
+        else{
+            return "";
+        }
+}
+vector<const Constant*>Xor::as_list() const {
+    vector<const Constant*> cl = vector<const Constant*>();
+    if (lhs != nullptr && rhs != nullptr){
+        auto l = lhs->as_const();
+        auto r = rhs->as_const();
+        if(!(l->type() & VALID_MATH_TYPES)){
+            Error::error(Error::INVALID_EXPRESSION_TYPE_FOR_OPERATION, "lhs", prse_type_to_string(l->type()), "Bitwise Xor", line);
+        }
+        if (!(r->type() & VALID_MATH_TYPES)){
+            Error::error(Error::INVALID_EXPRESSION_TYPE_FOR_OPERATION, "rhs", prse_type_to_string(l->type()), "Bitwise Xor", line);
+        }
+        string emit  = l->value() + " ^ " + r->value();
+        cl.push_back(ret(new Constant(l->type(), emit)));
+    }
+    return cl;
+}

--- a/src/lib/expressions/Bitwise.h
+++ b/src/lib/expressions/Bitwise.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Unary_operator.h"
+#include "Binary_operator.h"
+
+class Xor : public Binary_operator {
+    private:
+        int line;
+    public:
+        Xor(int line, const Expression* lhs, const Expression* rhs):Binary_operator(lhs, rhs), line(line){}
+        virtual const Constant* as_const() const;
+        virtual string value() const;
+        virtual vector<const Constant*> as_list() const;
+};

--- a/src/lib/expressions/Expressions.h
+++ b/src/lib/expressions/Expressions.h
@@ -14,3 +14,4 @@
 #include "Program_expression.h"
 #include "Singleton.h"
 #include "Variable.h"
+#include "Bitwise.h"

--- a/src/prse.l
+++ b/src/prse.l
@@ -59,7 +59,7 @@ length|len|size         { return LENGTH; }
 \-                           { return MINUS; }
 \*                           { return STAR; }
 \/                           { return SLASH; }
-\^                           { return CARET; }
+\^                           { return XOR; }
 \%                           { return MODULO; }
 
 "++"                         { return INCREMENT; }

--- a/src/prse.y
+++ b/src/prse.y
@@ -78,7 +78,7 @@
 %token MINUS 			   	"-"
 %token STAR 			   	"*"
 %token SLASH 			   	"/"
-%token CARET 			   	"^"
+%token XOR                  "^"
 %token MODULO               "%"
 %token INCREMENT 		   	"++"
 %token DECREMENT 		   	"--"
@@ -175,7 +175,7 @@
 %left LOGIC_EQ LOGIC_NE DOLLAR MODULO
 %left LOGIC_GREATER LOGIC_GREATER_EQUAL LOGIC_LESS LOGIC_LESS_EQUAL
 //%left I_STRING_PART
-%left PLUS MINUS STAR SLASH
+%left PLUS MINUS STAR SLASH XOR
 %%
 
 program:
@@ -843,6 +843,9 @@ non_empty_expression:
     }
     | expression LOGIC_OR expression {
         $$ = new Logic_Or($1, $3);
+    }
+    | expression XOR expression {
+        $$ = new Xor(line_count, $1, $3);
     }
     ;
 


### PR DESCRIPTION
Added bitwise XOR function using ^ with an example program which successfully compiles and runs (bitwise.prse).

Files Modified:
* prse.y
* prse.l
* expressions/Expressions.h

Files added:
* Bitwise.h
* Bitwise.cpp

Why?

I noticed the ^ token was in the parser and unused. I also wanted to possibly add things like bit shifts in the future.

Does it work?

Yes, I wrote a program that used the new binary operator and verified correct output. 

Prove it?

![image](https://github.com/user-attachments/assets/73b51026-9b53-40ac-9899-e4cdcb9df426)

![image](https://github.com/user-attachments/assets/57098bbd-7d66-471b-9a77-d4f236077ff6)

